### PR TITLE
update docker commands to remove ' (cmd issue)

### DIFF
--- a/v2/src/pages/docs/guides/blocking-activities.md
+++ b/v2/src/pages/docs/guides/blocking-activities.md
@@ -178,7 +178,7 @@ curl --location --request GET 'https://localhost:5001/v1/activities'
 Another way is to launch the Elsa Dashboard docker image if you have Docker installed with the following command:
 
 ```bash
-docker run -t -i -e ELSA__SERVER__BASEADDRESS='http://localhost:5000' -p 16000:80 elsaworkflows/elsa-dashboard:latest
+docker run -t -i -e ELSA__SERVER__BASEADDRESS=http://localhost:5000 -p 16000:80 elsaworkflows/elsa-dashboard:latest
 ```
 
 With that, Elsa Dashboard will be available via [http://localhost:12000](http://localhost:12000):

--- a/v2/src/pages/docs/guides/parent-child-workflows.md
+++ b/v2/src/pages/docs/guides/parent-child-workflows.md
@@ -10,7 +10,7 @@ We'll also see how we can provide input into the child workflows and allow the c
 You don't need to setup an Elsa project to follow this guide. All we need is a running [Elsa Server + Dashboard Docker container](/docs/quickstarts/elsa-docker) by running the following command:
 
 ```bash
-docker run -t -i -e ELSA__SERVER__BASEURL='http://localhost:13000' -p 13000:80 elsaworkflows/elsa-dashboard-and-server:latest
+docker run -t -i -e ELSA__SERVER__BASEURL=http://localhost:13000 -p 13000:80 elsaworkflows/elsa-dashboard-and-server:latest
 ```
 
 Next, we'll go over the following scenarios:

--- a/v2/src/pages/docs/guides/signaling-workflows.md
+++ b/v2/src/pages/docs/guides/signaling-workflows.md
@@ -21,7 +21,7 @@ To follow this guide, make sure to run Elsa Dashboard. If you have Docker instal
 docker run -t -i -p 13000:80 elsaworkflows/elsa-dashboard-and-server:latest
 ```
 
-This will start the Elsa Dashboard in a container which you can access from a web browser at `http://localhost:14000`.
+This will start the Elsa Dashboard in a container which you can access from a web browser at `http://localhost:13000`.
 
 ### Signal Sender Workflow
 

--- a/v2/src/pages/docs/guides/workflow-context.md
+++ b/v2/src/pages/docs/guides/workflow-context.md
@@ -353,7 +353,7 @@ Since we didn't setup Elsa Dashboard, we will need to run that separately in ord
 Run the following Docker command to do exactly that:
 
 ```bash
-docker run -t -i -e ELSA__SERVER__BASEADDRESS='http://localhost:5000' -p 14000:80 elsaworkflows/elsa-dashboard:latest
+docker run -t -i -e ELSA__SERVER__BASEADDRESS=http://localhost:5000 -p 14000:80 elsaworkflows/elsa-dashboard:latest
 ```
 
 Navigate to the dashboard at `http://localhost:14000/`

--- a/v2/src/pages/docs/quickstarts/elsa-docker.md
+++ b/v2/src/pages/docs/quickstarts/elsa-docker.md
@@ -5,7 +5,7 @@ title: Elsa + Docker
 If you have [Docker](http://docker.com/) installed, then running the Elsa Dashboard + Server Docker image is the quickest way to run the dashboard:
 
 ```bash
-docker run -t -i -e ELSA__SERVER__BASEURL='http://localhost:13000' -e ASPNETCORE_ENVIRONMENT='Development' -p 13000:80 elsaworkflows/elsa-dashboard-and-server:latest
+docker run -t -i -e ELSA__SERVER__BASEURL=http://localhost:13000 -e ASPNETCORE_ENVIRONMENT=Development -p 13000:80 elsaworkflows/elsa-dashboard-and-server:latest
 ```
 
 Notice that you can specify the Elsa Server URL by passing in an environment variable called `ELSA__SERVER__BASEURL`.

--- a/v3/src/pages/docs/installation/docker.md
+++ b/v3/src/pages/docs/installation/docker.md
@@ -30,7 +30,7 @@ Before trying to run the image, make sure you have [Docker](https://docs.docker.
 To run the image, simply run the following command from your terminal:
 
 ```shell
-docker run -t -i -e ASPNETCORE_ENVIRONMENT='Development' -p 13000:80 elsaworkflows/elsa-v3:latest
+docker run -t -i -e ASPNETCORE_ENVIRONMENT=Development -p 13000:80 elsaworkflows/elsa-v3:latest
 ```
 
 When the container has started, open a web browser and navigate to http://localhost:13000/.


### PR DESCRIPTION
Fix issue faced by users if they run docker command from Command Prompt.

The single quote (') gets encoded to &#x27; which breaks the dashboard configuration