### PR TITLE
Fix capitalization error in employee-onboarding.Json

### DIFF
--- a/v3/public/guides/external-app-integration/employee-onboarding.json
+++ b/v3/public/guides/external-app-integration/employee-onboarding.json
@@ -89,7 +89,7 @@
           "typeName": "String[]",
           "expression": {
             "type": "JavaScript",
-            "value": "getEmployee().email;"
+            "value": "getEmployee().Email;"
           }
         },
         "cc": null,


### PR DESCRIPTION
When testing this workflow, the "To" variable wasn't set. After some digging, I discovered this happened was because the "Email" field in the input json has a capital "E", while it is called on with GetEmployee().email with a non-capital "e". After changing the letter everything works as expected.