### PR TITLE
Fix csharp workflow variables inconsistent.

### DIFF
--- a/v3/src/pages/docs/expressions/csharp.md
+++ b/v3/src/pages/docs/expressions/csharp.md
@@ -26,9 +26,9 @@ The following functions are specific to handling workflow variables and input.
 
 | Function                            | Description                                | Example                                 |
 |-------------------------------------|--------------------------------------------|-----------------------------------------|
-| `Variables.Get(string): object?`    | Gets a variable from the workflow.         | `Variable.Get("MyVariable")`            |
-| `Variables.Set(string, object?)`    | Sets a variable in the workflow.           | `Variable.Set("MyVariable", "myValue")` |
-| `Variables.{VariableName}: object?` | Gets or sets a variable on the workflow.   | `Variable.MyVariable`                   |
+| `Variables.Get(string): object?`    | Gets a variable from the workflow.         | `Variables.Get("MyVariable")`            |
+| `Variables.Set(string, object?)`    | Sets a variable in the workflow.           | `Variables.Set("MyVariable", "myValue")` |
+| `Variables.{VariableName}: object?` | Gets or sets a variable on the workflow.   | `Variables.MyVariable`                   |
 | `Input.Get(string): object?`        | Gets the input of the workflow.            | `Input.Get('name')`                     |
 
 ### Workflow variables


### PR DESCRIPTION
**Section:** Workflow Variables and Input

**Problem:** The function and example are inconsistent: **`Variables`** / `Variable`

**Document URL:** [Workflow Variables and Input](https://v3.elsaworkflows.io/docs/expressions/csharp#workflow-variables-and-input)
