### PR TITLE
Update extensibility.md

### DIFF
--- a/v3/src/pages/docs/alterations/extensibility.md
+++ b/v3/src/pages/docs/alterations/extensibility.md
@@ -17,10 +17,10 @@ public interface IAlteration
 Next, implement an **alteration handler** that handles the alteration type.
 
 ```clike
-public interface IAlterationHandler where T : IAlteration
+public interface IAlterationHandler
 {
     bool CanHandle(IAlteration alteration);
-    ValueTask HandleAsync(AlterationHandlerContext context);
+    ValueTask HandleAsync(AlterationContext context);
 }
 ```
 
@@ -50,7 +50,7 @@ public class MyAlteration : IAlteration
 
 public class MyAlterationHandler : AlterationHandlerBase<MyAlteration>
 {
-    public override async ValueTask HandleAsync(AlterationHandlerContext<MyAlteration> context, CancellationToken cancellationToken = default)
+    public override async ValueTask HandleAsync(AlterationContext context, MyAlteration alteration)
     {
         context.WorkflowExecutionContext.Output.Add("Message", context.Alteration.Message);
     }


### PR DESCRIPTION
- Update context name in handler example
     - I checked the implementation used by AlterationHandlerBase example [here](https://github.com/elsa-workflows/elsa-core/blob/main/src/modules/Elsa.Alterations.Core/Contracts/IAlterationHandler.cs#L8) and updated accordingly
- Remove generic constraints in interface 
     - This shows the [CS0080](https://learn.microsoft.com/en-us/dotnet/csharp/misc/cs0080?f1url=%3FappId%3Droslyn%26k%3Dk(CS0080)) error when copied into an IDE
- Update AlterationHandlerBase example to correct parameters
     - I couldn't see an implementation which contained the parameters shown in the example.

Note: I only spent a couple of minutes trying but I couldn't see a way to pass custom types to the `.AddAlterations<T, THandler>()` API. 