### PR TITLE
Update framework version to .NET 8.0 in initial setup documentation

### DIFF
--- a/v3/src/pages/docs/getting-started/initial-setup-and-prerequisites.md
+++ b/v3/src/pages/docs/getting-started/initial-setup-and-prerequisites.md
@@ -19,7 +19,7 @@ For those who want a quick introduction to Elsa or wish to test workflows withou
 
 1. **Create a New Console Application**:
    ```bash
-   dotnet new console -n "ElsaConsole" -f net7.0
+   dotnet new console -n "ElsaConsole" -f net8.0
    ```
 
 2. **Install Elsa NuGet Packages**:


### PR DESCRIPTION
 In this PR, I've updated the dotnet new console command in the "initial-setup-and-prerequisites.md" page to reflect the use of .NET 8.0 instead of .NET 7.0. 